### PR TITLE
Removed dotnet setup from build task

### DIFF
--- a/Advent2020/build.yaml
+++ b/Advent2020/build.yaml
@@ -1,0 +1,21 @@
+name: .NET Core
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+    - name: Test
+      run: dotnet test --no-restore --verbosity normal


### PR DESCRIPTION
Should be on hte agent by default now the build image is updated